### PR TITLE
fix(CDVWKWebViewEngine): Fix iOS 12 keyboard dismissal scrolling to t…

### DIFF
--- a/src/ios/CDVWKWebViewEngine.h
+++ b/src/ios/CDVWKWebViewEngine.h
@@ -24,6 +24,7 @@
 
 @property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
 @property (nonatomic, strong) NSString * basePath;
+@property (nonatomic) CGPoint lastContentOffset;
 
 -(void)setServerBasePath:(CDVInvokedUrlCommand*)command;
 -(void)getServerBasePath:(CDVInvokedUrlCommand*)command;


### PR DESCRIPTION
…op of page

When the keyboard is dismissed on iOS 12 devices, the viewport will scroll to the top of the page
regardless of how far down the user had scrolled prior to opening the keyboard. This fixes this
issue by restoring the original scroll position when the keyboard was opened.